### PR TITLE
fix btag weight naming

### DIFF
--- a/MEAnalysis/python/metree.py
+++ b/MEAnalysis/python/metree.py
@@ -26,7 +26,7 @@ bweights = [
 for sdir in ["up", "down"]:
     for syst in ["cferr1", "cferr2", "hf", "hfstats1", "hfstats2", "jes", "lf", "lfstats1", "lfstats2"]:
         for tagger in ["CSV", "CMVAV2"]:
-            bweights += ["btagWeight{0}_{1}_{2}".format(tagger, syst, sdir)]
+            bweights += ["btagWeight{0}_{1}_{2}".format(tagger, sdir, syst)]
 
 #Specifies what to save for jets
 jetType = NTupleObjectType("jetType", variables = [

--- a/Plotting/python/joosep/sparsinator.py
+++ b/Plotting/python/joosep/sparsinator.py
@@ -31,17 +31,17 @@ ttH/sl/sparse_CMS_ttH_CSVJESUp -> event with btagWeight with JES up variation
 ...
 """
 systematic_weights = []
-btag_weights = []
-for sdir in ["up", "down"]:
-    for syst in ["cferr1", "cferr2", "hf", "hfstats1", "hfstats2", "jes", "lf", "lfstats1", "lfstats2"]:
-        for tagger in ["CSV", "CMVAV2"]:
-            bweight = "btagWeight{0}_{1}_{2}".format(tagger, syst, sdir)
-            #make systematic outputs consistent in Up/Down naming
-            sdir_cap = sdir.capitalize()
-            systematic_weights += [
-                ("CMS_ttH_{0}{1}{2}".format(tagger, syst, sdir_cap), lambda ev, bweight=bweight: ev["weight_nominal"]/ev["btagWeight"+tagger]*ev[bweight])
-            ]
-            btag_weights += [bweight]
+#btag_weights = []
+#for sdir in ["up", "down"]:
+#    for syst in ["cferr1", "cferr2", "hf", "hfstats1", "hfstats2", "jes", "lf", "lfstats1", "lfstats2"]:
+#        for tagger in ["CSV", "CMVAV2"]:
+#            bweight = "btagWeight{0}_{1}_{2}".format(tagger, sdir, syst)
+#            #make systematic outputs consistent in Up/Down naming
+#            sdir_cap = sdir.capitalize()
+#            systematic_weights += [
+#                ("CMS_ttH_{0}{1}{2}".format(tagger, syst, sdir_cap), lambda ev, bweight=bweight: ev["weight_nominal"]/ev["btagWeight"+tagger]*ev[bweight])
+#            ]
+#            btag_weights += [bweight]
 
 systematic_weights += [
         ("puUp", lambda ev: ev["weight_nominal"]/ev["puWeight"] * ev["puWeightUp"]),

--- a/Plotting/python/joosep/sparsinator.py
+++ b/Plotting/python/joosep/sparsinator.py
@@ -31,7 +31,7 @@ ttH/sl/sparse_CMS_ttH_CSVJESUp -> event with btagWeight with JES up variation
 ...
 """
 systematic_weights = []
-#btag_weights = []
+btag_weights = []
 #for sdir in ["up", "down"]:
 #    for syst in ["cferr1", "cferr2", "hf", "hfstats1", "hfstats2", "jes", "lf", "lfstats1", "lfstats2"]:
 #        for tagger in ["CSV", "CMVAV2"]:


### PR DESCRIPTION
btag weights in vhbb are `btagWeightCSV_down_cferr1` instead of `btagWeightCSV_cferr1_down`.

```
$ python MEAnalysis/test/getBranches.py root://storage01.lcg.cscs.ch//pnfs/lcg.cscs.ch/cms/trivcat/store/user/jpata/tth/Aug11_pilot_v1/ttHTobb_M125_13TeV_powheg_pythia8/Aug11_pilot_v1/160810_225429/0000/tree_10.root vhbb/tree | grep btagWeight

btagWeightCSV
btagWeightCSV_down_cferr1
btagWeightCSV_down_cferr2
btagWeightCSV_down_hf
```
